### PR TITLE
Improve the way to access the Twig_Environment

### DIFF
--- a/src/Porpaginas/Twig/PorpaginasExtension.php
+++ b/src/Porpaginas/Twig/PorpaginasExtension.php
@@ -26,32 +26,22 @@ class PorpaginasExtension extends Twig_Extension
      */
     private $adapter;
 
-    /**
-     * @var \Twig_Environment
-     */
-    private $environment;
-
     public function __construct(RenderingAdapter $adapter)
     {
         $this->adapter = $adapter;
     }
 
-    public function initRuntime(Twig_Environment $environment)
-    {
-        $this->environment = $environment;
-    }
-
     public function getFunctions()
     {
         return array(
-            new Twig_SimpleFunction('porpaginas_render', array($this, 'renderPagination'), array('is_safe' => array('html'))),
+            new Twig_SimpleFunction('porpaginas_render', array($this, 'renderPagination'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new Twig_SimpleFunction('porpaginas_total', array($this, 'renderTotal')),
         );
     }
 
-    public function renderPagination(Page $page)
+    public function renderPagination(Twig_Environment $environment, Page $page)
     {
-        return $this->adapter->renderPagination($page, $this->environment);
+        return $this->adapter->renderPagination($page, $environment);
     }
 
     public function renderTotal(Page $page)

--- a/tests/Porpaginas/Twig/PorpaginasExtensionTest.php
+++ b/tests/Porpaginas/Twig/PorpaginasExtensionTest.php
@@ -14,9 +14,8 @@ class PorpaginasExtensionTest extends \PHPUnit_Framework_TestCase
         $adapter = \Phake::mock('Porpaginas\Twig\RenderingAdapter');
 
         $extension = new PorpaginasExtension($adapter);
-        $extension->initRuntime($env);
 
-        $extension->renderPagination($page);
+        $extension->renderPagination($env, $page);
 
         \Phake::verify($adapter)->renderPagination($page, $env);
     }


### PR DESCRIPTION
Asking Twig to pass the environment when calling the environment instead of storing a reference in initRuntime avoids creating a circular reference in the object graph (as the environment contains the extension)