### PR TITLE
Improve the way to configure the test autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,9 @@
     "autoload": {
         "psr-0": {"Porpaginas\\": "src/"}
     },
+    "autoload-dev": {
+        "psr-0": {"Porpaginas\\": "tests/"}
+    },
     "require-dev": {
         "doctrine/orm": ">=2.2",
         "pagerfanta/pagerfanta": "@stable",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" ?>
-<phpunit bootstrap="tests/bootstrap.php">
+<phpunit bootstrap="vendor/autoload.php" colors="true">
     <testsuites>
         <testsuite name="Porpaginas">
             <directory>tests/</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,4 +5,10 @@
             <directory>tests/</directory>
         </testsuite>
     </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory>src</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,4 +1,0 @@
-<?php
-
-$loader = require_once __DIR__ . '/../vendor/autoload.php';
-$loader->add('Porpaginas', __DIR__);


### PR DESCRIPTION
Using autoload-dev rather than a bootstrap file to register the test autoloading is easier.
The bootstrap file was also incompatible with composer-installed phpunit because of its usage of _once to load the autoload.php file, which would return true rather than the ClassLoader if the file was already loaded previously.