### PR TITLE
Switch to the docker-based infrastructure on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 cache:
   directories:
     - $HOME/.composer/cache/files


### PR DESCRIPTION
Repos which are newly enabled on Travis are supposed to use it automatically, so I omitted it, but it is broken apparently and still requires an explicit config.