### PR TITLE
hardly depend on a Page object to make the pager iterable

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,17 +163,22 @@ We found a total of <strong>{{ porpaginas_total(users) }}</strong> users:
 You can use the `Porpaginas\Pager` class to help you get a slice of previous and next pages to display:
 
 ``` php
-$pager = Porpaginas\Pager::fromPage($page);
+$pager = Porpaginas\Pager::fromResult($result, $request->query->get('page', 1), 20);
 ```
 
 Passed to a twig template:
 
 ``` jinja
+
+{% for item in pager %}
+  {{ item.name }}
+{% endfor %}
+
 <nav class="pages">
     <ul>
         {% for page in pager.pages() %}
             <li class="{{ pager.isCurrent(page) ? 'active' }}">
-                <a href="{{ page }}">{{ page }}</a>
+                <a href="?page={{ page }}">{{ page }}</a>
             </li>
         {% endfor %}
     </ul>

--- a/src/Porpaginas/Pager.php
+++ b/src/Porpaginas/Pager.php
@@ -13,7 +13,7 @@ final class Pager implements \IteratorAggregate
     {
         $this->totalCount = $page->totalCount();
         $this->limit = $page->getCurrentLimit();
-        $this->currentPageNumber = max(1, $page->getCurrentPage());
+        $this->currentPageNumber = intval(max(1, $page->getCurrentPage()));
         $this->page = $page;
     }
 

--- a/tests/Porpaginas/PagerTest.php
+++ b/tests/Porpaginas/PagerTest.php
@@ -3,6 +3,8 @@
 namespace Porpaginas;
 
 use Porpaginas\Pager;
+use Porpaginas\Arrays\ArrayPage;
+use Porpaginas\Arrays\ArrayResult;
 
 final class PagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -11,8 +13,9 @@ final class PagerTest extends \PHPUnit_Framework_TestCase
      */
     public function it_gets_number_of_pages()
     {
-        $pager = new Pager(95, 20, 1);
-        $this->assertEquals($pager->getPages(), array(1, 2, 3, 4,));
+        $page = new ArrayPage(range(0, 19), 0, 20, 96);
+        $pager = new Pager($page);
+        $this->assertEquals(array(1, 2, 3, 4,), $pager->getPages());
     }
 
     /**
@@ -20,8 +23,9 @@ final class PagerTest extends \PHPUnit_Framework_TestCase
      */
     public function it_handles_negative_page_numbers()
     {
-        $pager = new Pager(95, 10, -42);
-        $this->assertEquals($pager->getPages(), array(1, 2, 3, 4,));
+        $page = new ArrayPage(range(0, 19), -42, 10, 95);
+        $pager = new Pager($page);
+        $this->assertEquals(array(1, 2, 3, 4,), $pager->getPages());
     }
 
     /**
@@ -29,8 +33,8 @@ final class PagerTest extends \PHPUnit_Framework_TestCase
      */
     public function it_handles_too_big_page_numbers()
     {
-        $pager = new Pager(95, 10, 42);
-        $this->assertEquals($pager->getPages(), array(7, 8, 9, 10));
+        $pager = Pager::fromResult(new ArrayResult(range(0, 99)), 500, 10);
+        $this->assertEquals(array(7, 8, 9, 10), $pager->getPages());
     }
 
     /**
@@ -38,7 +42,16 @@ final class PagerTest extends \PHPUnit_Framework_TestCase
      */
     public function it_handles_empty_lists()
     {
-        $pager = new Pager(0, 10, 42);
-        $this->assertEquals($pager->getPages(), array(1));
+        $pager = Pager::fromResult(new ArrayResult(array()), 5, 10);
+        $this->assertEquals(array(1), $pager->getPages());
+    }
+
+    /**
+     * @test
+     */
+    public function it_takes_a_page_given_a_page_number()
+    {
+        $pager = Pager::fromResult(new ArrayResult(range(0, 99)), 6, 10);
+        $this->assertEquals(array(50, 51, 52, 53, 54, 55, 56, 57, 58, 59), iterator_to_array($pager));
     }
 }


### PR DESCRIPTION
Ease construction of a pager object via Pager::fromResult.

I changed the way the Pager depends on Page. Now you have to pas it a `Page` instance,
but it eases the end-to-end usage: you only have to use `Pager::fromResult($result, $page, $numberPerPage)`
and you have a fully iterable pager:

```php
$pager = Pager::fromResult($result, $pageNumber, 10); // $page = 5

var_dump($pager->getPages(2); // as usual: [3, 4, *5*, 6, 7]

foreach ($pager as $item) {
    // iterate on paginated result
}
```

WDYT?