### PR TITLE
Fix page number handling

### DIFF
--- a/src/Porpaginas/Arrays/ArrayPage.php
+++ b/src/Porpaginas/Arrays/ArrayPage.php
@@ -44,7 +44,7 @@ class ArrayPage implements Page
      */
     public function getCurrentPage()
     {
-        return floor($this->offset / $this->limit) + 1;
+        return (int) floor($this->offset / $this->limit) + 1;
     }
 
     /**

--- a/src/Porpaginas/Doctrine/ORM/ORMQueryPage.php
+++ b/src/Porpaginas/Doctrine/ORM/ORMQueryPage.php
@@ -47,7 +47,7 @@ class ORMQueryPage implements Page
      */
     public function getCurrentPage()
     {
-        return floor($this->getCurrentOffset() / $this->getCurrentLimit()) + 1;
+        return (int) floor($this->getCurrentOffset() / $this->getCurrentLimit()) + 1;
     }
 
     /**

--- a/src/Porpaginas/Pager.php
+++ b/src/Porpaginas/Pager.php
@@ -32,7 +32,7 @@ final class Pager
 
     public function getNumberOfPages()
     {
-        return ceil($this->totalCount / $this->limit) ?: 1;
+        return (int) ceil($this->totalCount / $this->limit) ?: 1;
     }
 
     private function getSliceStart($siblings)


### PR DESCRIPTION
The fact that the concerned methods return a float messes up the behavior of `Porpaginas\Pager::isCurrent()`, as its `$page` argument is expected to be an integer (and the comparison thus fails while it's not expected to).