### PR TITLE
[minor] type hinting in interface Page.php

### DIFF
--- a/src/Porpaginas/Page.php
+++ b/src/Porpaginas/Page.php
@@ -53,7 +53,7 @@ interface Page extends Countable, IteratorAggregate
     /**
      * Return an iterator over selected windows of results of the paginatable.
      *
-     * @return Iterator
+     * @return \Iterator
      */
     public function getIterator();
 }


### PR DESCRIPTION
added missing leading backslash (interface `\Iterator`) in PHPDoc for method `getIterator()`