### PR TITLE
[minor] fixing Result PHPdoc

### DIFF
--- a/src/Porpaginas/Result.php
+++ b/src/Porpaginas/Result.php
@@ -26,6 +26,7 @@ interface Result extends Countable, IteratorAggregate
 {
     /**
      * @param int $offset
+     * @param int $limit
      * @return \Porpaginas\Page
      */
     public function take($offset, $limit);
@@ -40,7 +41,7 @@ interface Result extends Countable, IteratorAggregate
     /**
      * Return an iterator over all results of the paginatable.
      *
-     * @return Iterator
+     * @return \Iterator
      */
     public function getIterator();
 }


### PR DESCRIPTION
Change similar to PR #20 

I'm not usually bothered with PHPdoc, but in this specific case I have a phpstan error on my projects due to it interpretating that `Iterator` to be a non existing `Porpaginas\Iterator` class
(phpstan uses those PHPdoc typehints to check if )