### PR TITLE
Adding ReturnTypeWillChange to temporary allow no return type on interfaces when using php8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,9 @@
         "phake/phake": "@stable",
         "phpunit/phpunit": "^5.7"
     },
+    "require": {
+        "php": ">=8.1"
+    },
     "suggest": {
         "pagerfanta/pagerfanta": "For rendering pagination with Pagerfanta"
     }

--- a/src/Porpaginas/Page.php
+++ b/src/Porpaginas/Page.php
@@ -41,6 +41,7 @@ interface Page extends Countable, IteratorAggregate
      *
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count();
 
     /**
@@ -55,5 +56,6 @@ interface Page extends Countable, IteratorAggregate
      *
      * @return \Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator();
 }

--- a/src/Porpaginas/Result.php
+++ b/src/Porpaginas/Result.php
@@ -36,6 +36,7 @@ interface Result extends Countable, IteratorAggregate
 
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count();
 
     /**
@@ -43,5 +44,6 @@ interface Result extends Countable, IteratorAggregate
      *
      * @return \Iterator
      */
+    #[\ReturnTypeWillChange]
     public function getIterator();
 }


### PR DESCRIPTION
This PR is using ReturnTypeWillChange to slowly allow packages using porpaginas interfaces to supress the php fatal error introduced in 8.1 

```
Return type of Porpaginas\Result::getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice

 Return type of Porpaginas\Result::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice
```

A new major version need to be released to type the return type as integer / Iterator as it will break dependents packages.

I can update the type and all associated class if needed in another PR