### PR TITLE
Introduce PHPStan and generics types

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,16 @@ Central part of this library is the interface `Result`:
 <?php
 namespace Porpaginas;
 
+/**
+ * @template-covariant T
+ * @extends IteratorAggregate<array-key, T>
+ */
 interface Result extends Countable, IteratorAggregate
 {
     /**
      * @param int $offset
      * @param int $limit
-     * @return Page
+     * @return Page<T>
      */
     public function take($offset, $limit);
 
@@ -45,7 +49,7 @@ interface Result extends Countable, IteratorAggregate
     /**
      * Return an iterator over all results of the paginatable.
      *
-     * @return Iterator
+     * @return Traversable<array-key, T>
      */
     public function getIterator();
 }
@@ -64,6 +68,10 @@ looks like this:
 
 namespace Porpaginas;
 
+/**
+ * @template-covariant T
+ * @extends IteratorAggregate<array-key, T>
+ */
 interface Page extends Countable, IteratorAggregate
 {
     /**
@@ -83,7 +91,7 @@ interface Page extends Countable, IteratorAggregate
     /**
      * Return an iterator over selected windows of results of the paginatable.
      *
-     * @return Iterator
+     * @return Traversable<array-key, T>
      */
     public function getIterator();
 }
@@ -106,7 +114,7 @@ Take the following example using Doctrine ORM:
 class UserRepository extends EntityRepository
 {
     /**
-     * @return \Porpaginas\Result
+     * @return \Porpaginas\Result<User>
      */
     public function findAllUsers()
     {
@@ -140,6 +148,7 @@ class UserController
         return array('users' => $paginator);
     }
 }
+
 ```
 
 Now in the template for `porpaginasListAction` using the `porpaginas` Twig

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,11 @@
         "twig/twig": "@stable",
         "phake/phake": "@stable",
         "phpunit/phpunit": "^7|^8|^9",
-        "symfony/cache": "@stable"
+        "symfony/cache": "@stable",
+        "phpstan/phpstan": "^2.1"
+    },
+    "scripts": {
+        "phpstan": "phpstan analyse --debug"
     },
     "suggest": {
         "pagerfanta/pagerfanta": "For rendering pagination with Pagerfanta"

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,17 @@
+parameters:
+    level: 6
+    paths:
+        - src
+        - tests
+    ignoreErrors:
+        -
+            message: '#Call to an undefined method Phake\\Proxies\\StubberProxy::getExtension\(\)#'
+            path: tests/Porpaginas/Twig/KnpPagerRenderingAdapterTest.php
+        -
+            message: '#Call to an undefined method Phake\\Proxies\\VerifierProxy::render\(\)#'
+            path: tests/Porpaginas/Twig/KnpPagerRenderingAdapterTest.php
+        -
+            message: '#Call to an undefined method Phake\\Proxies\\VerifierProxy::renderPagination\(\)#'
+            path: tests/Porpaginas/Twig/PorpaginasExtensionTest.php
+    parallel:
+        maximumNumberOfProcesses: 1

--- a/src/Porpaginas/Arrays/ArrayPage.php
+++ b/src/Porpaginas/Arrays/ArrayPage.php
@@ -16,13 +16,38 @@ namespace Porpaginas\Arrays;
 use Porpaginas\Page;
 use ArrayIterator;
 
+/**
+ * @template T
+ * @implements Page<T>
+ */
 class ArrayPage implements Page
 {
+    /**
+     * @var array<array-key, T>
+     */
     private $slice;
+
+    /**
+     * @var int
+     */
     private $offset;
+
+    /**
+     * @var int
+     */
     private $limit;
+
+    /**
+     * @var int
+     */
     private $totalCount;
 
+    /**
+     * @param array<array-key, T> $slice
+     * @param int $offset
+     * @param int $limit
+     * @param int $totalCount
+     */
     public function __construct(array $slice, $offset, $limit, $totalCount)
     {
         $this->slice = $slice;
@@ -78,7 +103,7 @@ class ArrayPage implements Page
     /**
      * Return an iterator over selected windows of results of the paginatable.
      *
-     * @return Iterator
+     * @return ArrayIterator<array-key, T>
      */
     public function getIterator()
     {

--- a/src/Porpaginas/Arrays/ArrayResult.php
+++ b/src/Porpaginas/Arrays/ArrayResult.php
@@ -16,10 +16,20 @@ namespace Porpaginas\Arrays;
 use Porpaginas\Result;
 use ArrayIterator;
 
+/**
+ * @template T
+ * @implements Result<T>
+ */
 class ArrayResult implements Result
 {
+    /**
+     * @var array<array-key, T>
+     */
     private $data;
 
+    /**
+     * @param array<array-key, T> $data
+     */
     public function __construct(array $data)
     {
         $this->data = $data;
@@ -27,7 +37,8 @@ class ArrayResult implements Result
 
     /**
      * @param int $offset
-     * @return \Porpaginas\Page
+     * @param int $limit
+     * @return \Porpaginas\Page<T>
      */
     public function take($offset, $limit)
     {
@@ -53,7 +64,7 @@ class ArrayResult implements Result
     /**
      * Return an iterator over all results of the paginatable.
      *
-     * @return Iterator
+     * @return ArrayIterator<array-key, T>
      */
     #[\ReturnTypeWillChange]
     public function getIterator()

--- a/src/Porpaginas/Doctrine/ORM/ORMQueryPage.php
+++ b/src/Porpaginas/Doctrine/ORM/ORMQueryPage.php
@@ -17,18 +17,25 @@ use Porpaginas\Page;
 use Doctrine\ORM\Tools\Pagination\Paginator;
 use ArrayIterator;
 
+/**
+ * @template T
+ * @implements Page<T>
+ */
 class ORMQueryPage implements Page
 {
     /**
-     * @var \Doctrine\ORM\Tools\Pagination\Paginator
+     * @var Paginator<T>
      */
     private $paginator;
 
     /**
-     * @var array
+     * @var array<array-key, T>|null
      */
     private $result;
 
+    /**
+     * @param Paginator<T> $paginator
+     */
     public function __construct(Paginator $paginator)
     {
         $this->paginator = $paginator;
@@ -85,14 +92,17 @@ class ORMQueryPage implements Page
     /**
      * Return an iterator over selected windows of results of the paginatable.
      *
-     * @return Iterator
+     * @return \Traversable<array-key, T>
      */
     public function getIterator()
     {
-        if ($this->result) {
+        if ($this->result !== null) {
             return new ArrayIterator($this->result);
         }
 
-        return $this->paginator;
+        /** @var \Traversable<array-key, T> $iterator */
+        $iterator = $this->paginator;
+
+        return $iterator;
     }
 }

--- a/src/Porpaginas/Doctrine/ORM/ORMQueryResult.php
+++ b/src/Porpaginas/Doctrine/ORM/ORMQueryResult.php
@@ -22,10 +22,14 @@ use Doctrine\ORM\Tools\Pagination\Paginator;
 
 use ArrayIterator;
 
+/**
+ * @template T
+ * @implements Result<T>
+ */
 class ORMQueryResult implements Result
 {
     /**
-     * @var \Doctrine\ORM\Query
+     * @var Query
      */
     private $query;
 
@@ -35,7 +39,7 @@ class ORMQueryResult implements Result
     private $fetchCollection;
 
     /**
-     * @var array
+     * @var array<array-key, T>|null
      */
     private $result;
 
@@ -44,6 +48,10 @@ class ORMQueryResult implements Result
      */
     private $count;
 
+    /**
+     * @param Query|QueryBuilder $query
+     * @param bool $fetchCollection
+     */
     public function __construct($query, $fetchCollection = true)
     {
         if ($query instanceof QueryBuilder) {
@@ -56,7 +64,8 @@ class ORMQueryResult implements Result
 
     /**
      * @param int $offset
-     * @return \Porpaginas\Page
+     * @param int $limit
+     * @return \Porpaginas\Page<T>
      */
     public function take($offset, $limit)
     {
@@ -97,7 +106,7 @@ class ORMQueryResult implements Result
     /**
      * Return an iterator over all results of the paginatable.
      *
-     * @return Iterator
+     * @return ArrayIterator<array-key, T>
      */
     public function getIterator()
     {

--- a/src/Porpaginas/Iterator/IteratorPage.php
+++ b/src/Porpaginas/Iterator/IteratorPage.php
@@ -15,10 +15,14 @@ namespace Porpaginas\Iterator;
 
 use Porpaginas\Page;
 
+/**
+ * @template T
+ * @implements Page<T>
+ */
 class IteratorPage implements Page
 {
     /**
-     * @var \Iterator
+     * @var \Iterator<array-key, T>&\Countable
      */
     private $iterator;
     
@@ -38,7 +42,7 @@ class IteratorPage implements Page
     private $totalCount;
 
     /**
-     * @param \Iterator $iterator
+     * @param \Iterator<array-key, T>&\Countable $iterator
      * @param int $offset
      * @param int $limit
      * @param int $totalCount
@@ -68,7 +72,7 @@ class IteratorPage implements Page
             return 1;
         }
 
-        return floor($this->offset / $this->limit) + 1;
+        return (int) floor($this->offset / $this->limit) + 1;
     }
 
     /**

--- a/src/Porpaginas/KnpPager/PorpaginasSubscriber.php
+++ b/src/Porpaginas/KnpPager/PorpaginasSubscriber.php
@@ -9,6 +9,9 @@ use Knp\Component\Pager\Event\ItemsEvent;
 
 class PorpaginasSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @return void
+     */
     public function items(ItemsEvent $event)
     {
         if ( ! ($event->target instanceof Page)) {
@@ -22,7 +25,7 @@ class PorpaginasSubscriber implements EventSubscriberInterface
         $event->stopPropagation();
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return array(
             'knp_pager.items' => array('items', 0)

--- a/src/Porpaginas/Page.php
+++ b/src/Porpaginas/Page.php
@@ -17,7 +17,10 @@ use IteratorAggregate;
 use Countable;
 
 /**
- * Interface for lazy paginators
+ * Interface for lazy paginators.
+ *
+ * @template-covariant T
+ * @extends IteratorAggregate<array-key, T>
  */
 interface Page extends Countable, IteratorAggregate
 {
@@ -54,7 +57,7 @@ interface Page extends Countable, IteratorAggregate
     /**
      * Return an iterator over selected windows of results of the paginatable.
      *
-     * @return \Iterator
+     * @return \Traversable<array-key, T>&\Countable
      */
     #[\ReturnTypeWillChange]
     public function getIterator();

--- a/src/Porpaginas/Pager.php
+++ b/src/Porpaginas/Pager.php
@@ -4,10 +4,26 @@ namespace Porpaginas;
 
 final class Pager
 {
+    /**
+     * @var int
+     */
     private $totalCount;
+
+    /**
+     * @var int
+     */
     private $limit;
+
+    /**
+     * @var int
+     */
     private $currentPage;
 
+    /**
+     * @param int $totalCount
+     * @param int $limit
+     * @param int $currentPage
+     */
     public function __construct($totalCount, $limit, $currentPage)
     {
         $this->totalCount = $totalCount;
@@ -15,26 +31,45 @@ final class Pager
         $this->currentPage = max(1, $currentPage);
     }
 
+    /**
+     * @param Page<mixed> $page
+     * @return self
+     */
     public static function fromPage(Page $page)
     {
         return new self($page->totalCount(), $page->getCurrentLimit(), $page->getCurrentPage());
     }
 
+    /**
+     * @param int $page
+     * @return bool
+     */
     public function isCurrent($page)
     {
         return $this->currentPage === $page;
     }
 
+    /**
+     * @param int $siblings
+     * @return list<int>
+     */
     public function getPages($siblings = 3)
     {
         return range($this->getSliceStart($siblings), $this->getSliceEnd($siblings));
     }
 
+    /**
+     * @return int
+     */
     public function getNumberOfPages()
     {
         return (int) ceil($this->totalCount / $this->limit) ?: 1;
     }
 
+    /**
+     * @param int $siblings
+     * @return int
+     */
     private function getSliceStart($siblings)
     {
         return min(
@@ -43,6 +78,10 @@ final class Pager
         );
     }
 
+    /**
+     * @param int $siblings
+     * @return int
+     */
     private function getSliceEnd($siblings)
     {
         return max(1, min($this->getNumberOfPages(), $this->currentPage + $siblings));

--- a/src/Porpaginas/Pagerfanta/PorpaginasAdapter.php
+++ b/src/Porpaginas/Pagerfanta/PorpaginasAdapter.php
@@ -3,13 +3,24 @@
 namespace Porpaginas\Pagerfanta;
 
 use Pagerfanta\Adapter\AdapterInterface;
+use Porpaginas\Page;
 use Porpaginas\Result;
 
+/**
+ * @template T
+ * @implements AdapterInterface<T>
+ */
 class PorpaginasAdapter implements AdapterInterface
 {
+    /**
+     * @var Result<T>|Page<T>
+     */
     private $result;
 
-    public function __construct(Result $result)
+    /**
+     * @param Result<T>|Page<T> $result
+     */
+    public function __construct(Result|Page $result)
     {
         $this->result = $result;
     }
@@ -21,6 +32,10 @@ class PorpaginasAdapter implements AdapterInterface
      */
     function getNbResults(): int
     {
+        if ($this->result instanceof Page) {
+            return $this->result->totalCount();
+        }
+
         return $this->result->take(0, 1)->totalCount();
     }
 
@@ -30,10 +45,14 @@ class PorpaginasAdapter implements AdapterInterface
      * @param integer $offset The offset.
      * @param integer $length The length.
      *
-     * @return array|\Traversable The slice.
+     * @return iterable<array-key, T> The slice.
      */
     function getSlice(int $offset, int $length): iterable
     {
+        if ($this->result instanceof Page) {
+            return iterator_to_array($this->result);
+        }
+
         return iterator_to_array($this->result->take($offset, $length));
     }
 }

--- a/src/Porpaginas/Result.php
+++ b/src/Porpaginas/Result.php
@@ -21,13 +21,16 @@ use IteratorAggregate;
  *
  * It allows iterating over the result either paginated using the {@link take}
  * method or non-paginated using the iterator aggregate API.
+ *
+ * @template-covariant T
+ * @extends IteratorAggregate<array-key, T>
  */
 interface Result extends Countable, IteratorAggregate
 {
     /**
      * @param int $offset
      * @param int $limit
-     * @return \Porpaginas\Page
+     * @return Page<T>
      */
     public function take($offset, $limit);
 
@@ -42,7 +45,7 @@ interface Result extends Countable, IteratorAggregate
     /**
      * Return an iterator over all results of the paginatable.
      *
-     * @return \Iterator
+     * @return \Traversable<array-key, T>
      */
     #[\ReturnTypeWillChange]
     public function getIterator();

--- a/src/Porpaginas/Twig/KnpPagerRenderingAdapter.php
+++ b/src/Porpaginas/Twig/KnpPagerRenderingAdapter.php
@@ -8,9 +8,19 @@ use Knp\Component\Pager\Paginator;
 
 class KnpPagerRenderingAdapter implements RenderingAdapter
 {
+    /**
+     * @var Paginator
+     */
     private $paginator;
+
+    /**
+     * @var string|null
+     */
     private $template;
 
+    /**
+     * @param string|null $template
+     */
     public function __construct(Paginator $paginator, $template = null)
     {
         $this->paginator = $paginator;
@@ -18,11 +28,15 @@ class KnpPagerRenderingAdapter implements RenderingAdapter
     }
 
     /**
+     * @param Page<mixed> $page
      * @return string
      */
     public function renderPagination(Page $page, Environment $environment)
     {
-        return $environment->getExtension('knp_pagination')->render(
+        $method = new \ReflectionMethod($environment, 'getExtension');
+        $extension = $method->invoke($environment, 'knp_pagination');
+
+        return $extension->render(
             $this->paginator->paginate(
                 $page,
                 $page->getCurrentPage(),

--- a/src/Porpaginas/Twig/PagerfantaRenderingAdapter.php
+++ b/src/Porpaginas/Twig/PagerfantaRenderingAdapter.php
@@ -21,15 +21,19 @@ use Twig\Environment;
 class PagerfantaRenderingAdapter implements RenderingAdapter
 {
     /**
-     * @var string
+     * @var string|null
      */
     private $viewName;
 
     /**
-     * @var array
+     * @var array<array-key, mixed>
      */
     private $options;
 
+    /**
+     * @param string|null $viewName
+     * @param array<array-key, mixed> $options
+     */
     public function __construct($viewName = null, $options = array())
     {
         $this->viewName = $viewName;
@@ -37,6 +41,7 @@ class PagerfantaRenderingAdapter implements RenderingAdapter
     }
 
     /**
+     * @param Page<mixed> $page
      * @return string
      */
     public function renderPagination(Page $page, Environment $environment)
@@ -45,7 +50,10 @@ class PagerfantaRenderingAdapter implements RenderingAdapter
         $pagerfanta->setCurrentPage($page->getCurrentPage());
         $pagerfanta->setMaxPerPage($page->getCurrentLimit());
 
-        return $environment->getExtension('pagerfanta')->renderPagerfanta(
+        $method = new \ReflectionMethod($environment, 'getExtension');
+        $extension = $method->invoke($environment, 'pagerfanta');
+
+        return $extension->renderPagerfanta(
             $pagerfanta, $this->viewName, $this->options
         );
     }

--- a/src/Porpaginas/Twig/PorpaginasExtension.php
+++ b/src/Porpaginas/Twig/PorpaginasExtension.php
@@ -22,7 +22,7 @@ use Twig\TwigFunction;
 class PorpaginasExtension extends Extension\AbstractExtension
 {
     /**
-     * @var \Porpaginas\Twig\RenderingAdapter
+     * @var RenderingAdapter
      */
     private $adapter;
 
@@ -31,6 +31,9 @@ class PorpaginasExtension extends Extension\AbstractExtension
         $this->adapter = $adapter;
     }
 
+    /**
+     * @return array<int, TwigFunction>
+     */
     public function getFunctions()
     {
         return array(
@@ -39,16 +42,27 @@ class PorpaginasExtension extends Extension\AbstractExtension
         );
     }
 
+    /**
+     * @param Page<mixed> $page
+     * @return string
+     */
     public function renderPagination(Environment $environment, Page $page)
     {
         return $this->adapter->renderPagination($page, $environment);
     }
 
+    /**
+     * @param Page<mixed> $page
+     * @return int
+     */
     public function renderTotal(Page $page)
     {
         return $page->totalCount();
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return 'Porpaginas';

--- a/src/Porpaginas/Twig/RenderingAdapter.php
+++ b/src/Porpaginas/Twig/RenderingAdapter.php
@@ -19,6 +19,7 @@ use Twig\Environment;
 interface RenderingAdapter
 {
     /**
+     * @param Page<mixed> $page
      * @return string
      */
     public function renderPagination(Page $page, Environment $environment);

--- a/tests/Porpaginas/AbstractResultTestCase.php
+++ b/tests/Porpaginas/AbstractResultTestCase.php
@@ -9,7 +9,7 @@ abstract class AbstractResultTestCase extends TestCase
     /**
      * @test
      */
-    public function it_counts_total_items()
+    public function it_counts_total_items(): void
     {
         $result = $this->createResultWithItems(2);
 
@@ -19,7 +19,7 @@ abstract class AbstractResultTestCase extends TestCase
     /**
      * @test
      */
-    public function it_iterates_over_all_items()
+    public function it_iterates_over_all_items(): void
     {
         $result = $this->createResultWithItems(11);
 
@@ -29,7 +29,7 @@ abstract class AbstractResultTestCase extends TestCase
     /**
      * @test
      */
-    public function it_takes_slice_as_page()
+    public function it_takes_slice_as_page(): void
     {
         $result = $this->createResultWithItems(11);
 
@@ -45,7 +45,7 @@ abstract class AbstractResultTestCase extends TestCase
     /**
      * @test
      */
-    public function it_counts_last_page_of_slice_correctly()
+    public function it_counts_last_page_of_slice_correctly(): void
     {
         $result = $this->createResultWithItems(11);
 
@@ -60,7 +60,7 @@ abstract class AbstractResultTestCase extends TestCase
     /**
      * @test
      */
-    public function it_counts_page_first_then_iterates()
+    public function it_counts_page_first_then_iterates(): void
     {
         $result = $this->createResultWithItems(16);
 
@@ -73,7 +73,7 @@ abstract class AbstractResultTestCase extends TestCase
     /**
      * @test
      */
-    public function it_itereates_first_then_counts_page()
+    public function it_itereates_first_then_counts_page(): void
     {
         $result = $this->createResultWithItems(16);
 
@@ -83,5 +83,8 @@ abstract class AbstractResultTestCase extends TestCase
         $this->assertCount(5, $page);
     }
 
-    abstract protected function createResultWithItems($count);
+    /**
+     * @return Result<mixed>
+     */
+    abstract protected function createResultWithItems(int $count): Result;
 }

--- a/tests/Porpaginas/ArrayTest.php
+++ b/tests/Porpaginas/ArrayTest.php
@@ -6,7 +6,10 @@ use Porpaginas\Arrays\ArrayResult;
 
 class ArrayTest extends AbstractResultTestCase
 {
-    protected function createResultWithItems($count)
+    /**
+     * @return Result<string>
+     */
+    protected function createResultWithItems(int $count): Result
     {
         return new ArrayResult(array_fill(0, $count, 'value'));
     }

--- a/tests/Porpaginas/DoctrineORMQueryTest.php
+++ b/tests/Porpaginas/DoctrineORMQueryTest.php
@@ -15,7 +15,10 @@ use Doctrine\DBAL\DriverManager;
 
 class DoctrineORMQueryTest extends AbstractResultTestCase
 {
-    protected function createResultWithItems($count)
+    /**
+     * @return Result<DoctrineOrmEntity>
+     */
+    protected function createResultWithItems(int $count): Result
     {
         $entityManager = $this->setupEntityManager();
 
@@ -30,7 +33,7 @@ class DoctrineORMQueryTest extends AbstractResultTestCase
         return new ORMQueryResult($query);
     }
 
-    private function setupEntityManager()
+    private function setupEntityManager(): EntityManager
     {
         $paths = array();
         $isDevMode = false;
@@ -41,7 +44,23 @@ class DoctrineORMQueryTest extends AbstractResultTestCase
             'memory' => true,
         );
 
-        $config = ORMSetup::createAttributeMetadataConfiguration($paths, $isDevMode);
+        $createConfigMethod = 'createAttributeMetadataConfig';
+        // @phpstan-ignore-next-line compatibility with Doctrine ORM versions that do not have this method
+        if (method_exists(ORMSetup::class, $createConfigMethod)) {
+            $config = ORMSetup::{$createConfigMethod}($paths, $isDevMode);
+        } else {
+            $config = ORMSetup::createAttributeMetadataConfiguration($paths, $isDevMode);
+        }
+
+        $enableNativeLazyObjectsMethod = 'enableNativeLazyObjects';
+        // @phpstan-ignore-next-line compatibility with Doctrine ORM versions that do not have this method
+        if (\PHP_VERSION_ID >= 80400 && method_exists($config, $enableNativeLazyObjectsMethod)) {
+            $config->{$enableNativeLazyObjectsMethod}(true);
+        } else {
+            $config->setProxyDir(sys_get_temp_dir());
+            $config->setProxyNamespace('Proxies');
+        }
+
         $connection = DriverManager::getConnection($dbParams, $config);
         $entityManager = new EntityManager($connection, $config);
 
@@ -58,5 +77,6 @@ class DoctrineORMQueryTest extends AbstractResultTestCase
 class DoctrineOrmEntity
 {
     #[Id, Column(type: "integer"), GeneratedValue]
-    private $id;
+    // @phpstan-ignore property.unused
+    private int $id;
 }

--- a/tests/Porpaginas/KnpPager/PorpaginasSubscriberTest.php
+++ b/tests/Porpaginas/KnpPager/PorpaginasSubscriberTest.php
@@ -12,7 +12,7 @@ class PorpaginasSubscriberTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_and_converts_page()
+    public function it_handles_and_converts_page(): void
     {
         $argumentAccess = \Phake::mock(ArgumentAccessInterface::class);
         $event = new ItemsEvent(10, 10, $argumentAccess);

--- a/tests/Porpaginas/PagerTest.php
+++ b/tests/Porpaginas/PagerTest.php
@@ -10,7 +10,7 @@ final class PagerTest extends TestCase
     /**
      * @test
      */
-    public function it_gets_number_of_pages()
+    public function it_gets_number_of_pages(): void
     {
         $pager = new Pager(95, 20, 1);
         $this->assertEquals($pager->getPages(), array(1, 2, 3, 4,));
@@ -19,7 +19,7 @@ final class PagerTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_negative_page_numbers()
+    public function it_handles_negative_page_numbers(): void
     {
         $pager = new Pager(95, 10, -42);
         $this->assertEquals($pager->getPages(), array(1, 2, 3, 4,));
@@ -28,7 +28,7 @@ final class PagerTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_too_big_page_numbers()
+    public function it_handles_too_big_page_numbers(): void
     {
         $pager = new Pager(95, 10, 42);
         $this->assertEquals($pager->getPages(), array(7, 8, 9, 10));
@@ -37,7 +37,7 @@ final class PagerTest extends TestCase
     /**
      * @test
      */
-    public function it_handles_empty_lists()
+    public function it_handles_empty_lists(): void
     {
         $pager = new Pager(0, 10, 42);
         $this->assertEquals($pager->getPages(), array(1));

--- a/tests/Porpaginas/Pagerfanta/PorpaginasAdapterTest.php
+++ b/tests/Porpaginas/Pagerfanta/PorpaginasAdapterTest.php
@@ -11,7 +11,7 @@ class PorpaginasAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_counts_total_number_of_results()
+    public function it_counts_total_number_of_results(): void
     {
         $pagerfanta = new Pagerfanta(
             new PorpaginasAdapter(
@@ -25,7 +25,7 @@ class PorpaginasAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_iterates_slice()
+    public function it_iterates_slice(): void
     {
         $pagerfanta = new Pagerfanta(
             new PorpaginasAdapter(

--- a/tests/Porpaginas/Twig/KnpPagerRenderingAdapterTest.php
+++ b/tests/Porpaginas/Twig/KnpPagerRenderingAdapterTest.php
@@ -16,7 +16,7 @@ class KnpPagerRenderingAdapterTest extends TestCase
     /**
      * @test
      */
-    public function it_renders_pagination_delegating_to_twig_knppagination()
+    public function it_renders_pagination_delegating_to_twig_knppagination(): void
     {
         $env = \Phake::mock('Twig\Environment');
         $extension = \Phake::mock('Porpaginas\Twig\KnpPaginationExtension');
@@ -49,11 +49,16 @@ class KnpPagerRenderingAdapterTest extends TestCase
 
 class KnpPaginationExtension extends \Twig\Extension\AbstractExtension
 {
+    /**
+     * @param mixed $items
+     * @param mixed $template
+     * @return void
+     */
     public function render($items, $template)
     {
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'knp_pagination';
     }

--- a/tests/Porpaginas/Twig/PorpaginasExtensionTest.php
+++ b/tests/Porpaginas/Twig/PorpaginasExtensionTest.php
@@ -8,7 +8,7 @@ class PorpaginasExtensionTest extends TestCase
     /**
      * @test
      */
-    public function it_delegates_render_pagination_to_adapter()
+    public function it_delegates_render_pagination_to_adapter(): void
     {
         $env = \Phake::mock('Twig\Environment');
         $page = \Phake::mock('Porpaginas\Page');


### PR DESCRIPTION
Alternative to #27 as we both worked on it in parallel.

My main goal was to validate that the generic types work as expected by addeding PHPStan to the test suite as well as the codebase itself.

--

Enabling PHPs way of doing Generics help consumers of this lib to not have to annotate or assert types.

At it's core this annotates  Result<T> / Page<T> so item types survive take() and iteration.

I tried to keep the implementation BC-conscious: Public and extendable APIs were not tightened with new native parameter/return types in the code, but just in PHPDoc to not cause issues.

--

I did not upgrade PHPUnit or other dependencies in this, but testing with 8.5 and current dependencies made the changes to tests/Porpaginas/DoctrineORMQueryTest.php necessary.